### PR TITLE
allow first mask character to not be special

### DIFF
--- a/dist/format.js
+++ b/dist/format.js
@@ -12,6 +12,11 @@ exports.default = function (data, mask) {
     var c = data.charAt(i);
     var m = mask.charAt(i);
 
+    if (data.length == 1 && i == 0 && i + 1 < mask.length && /^((?!(#|A|N|X)).)*/.test(m)) {
+        text += m;
+        m = mask.charAt(i + 1);
+    }
+
     switch (m) {
       case '#':
         if (/\d/.test(c)) {

--- a/src/format.js
+++ b/src/format.js
@@ -15,6 +15,11 @@ export default function (data, mask){
     let c = data.charAt(i);
     let m = mask.charAt(i);
 
+    if (data.length == 1 && i == 0 && i + 1 < mask.length && /^((?!(#|A|N|X)).)*/.test(m)) {
+        text += m;
+        m = mask.charAt(i + 1);
+    }
+
     switch (m) {
       case '#' : if (/\d/.test(c))        {text += c;} else {x = 0;} break;
       case 'A' : if (/[a-z]/i.test(c))    {text += c;} else {x = 0;} break;


### PR DESCRIPTION
I ran into an issue where I set my mask to "(###) ###-####".  No matter what the first key press was, even if it was numeric, the key would get eaten and would only show "(".  The additional if I added is ugly I admit but it's the only way I could come up with to allow the first valid key press to insert both the non-special character and the first special character.  Testing has been limited to the above format but I don't see why things shouldn't work once you are past the first character.