### PR TITLE
Vue 2.0: allow multiple default characters at the beginning

### DIFF
--- a/dist/format.js
+++ b/dist/format.js
@@ -7,15 +7,16 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = function (data, mask) {
   if (!mask) return data;
 
+  var maskStartRegExp = /^([^#ANX]+)/;
+
+  if (data.length == 1 && maskStartRegExp.test(mask)) {
+    data = maskStartRegExp.exec(data)[0] + data;
+  }
+
   var text = '';
   for (var i = 0, x = 1; x && i < mask.length; ++i) {
     var c = data.charAt(i);
     var m = mask.charAt(i);
-
-    if (data.length == 1 && i == 0 && i + 1 < mask.length && /^((?!(#|A|N|X)).)*/.test(m)) {
-      text += m;
-      m = mask.charAt(i + 1);
-    }
 
     switch (m) {
       case '#':

--- a/dist/format.js
+++ b/dist/format.js
@@ -43,7 +43,7 @@ exports.default = function (data, mask) {
         text += m;
 
         if (c && c !== m) {
-          data += c;
+          data = ' ' + data;
         }
 
         break;

--- a/dist/format.js
+++ b/dist/format.js
@@ -10,7 +10,7 @@ exports.default = function (data, mask) {
   var maskStartRegExp = /^([^#ANX]+)/;
 
   if (data.length == 1 && maskStartRegExp.test(mask)) {
-    data = maskStartRegExp.exec(data)[0] + data;
+    data = maskStartRegExp.exec(mask)[0] + data;
   }
 
   var text = '';

--- a/dist/format.js
+++ b/dist/format.js
@@ -40,7 +40,13 @@ exports.default = function (data, mask) {
       case 'X':
         text += c;break;
       default:
-        text += m;break;
+        text += m;
+
+        if (c && c !== m) {
+          data += c;
+        }
+
+        break;
     }
   }
   return text;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-mask",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "description": "Simple input mask lib for vue.js",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-mask",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Simple input mask lib for vue.js",
   "main": "dist/index.js",
   "scripts": {

--- a/src/format.js
+++ b/src/format.js
@@ -10,15 +10,16 @@ export default function (data, mask){
   // don't do anything if mask is undefined/null/etc
   if(!mask) return data;
 
+  const maskStartRegExp = /^([^#ANX]+)/;
+
+  if (data.length == 1 && maskStartRegExp.test(mask)) {
+    data = maskStartRegExp.exec(mask)[0] + data;
+  }
+
   let text = '';
   for (let i = 0, x = 1; x && i < mask.length; ++i) {
     let c = data.charAt(i);
     let m = mask.charAt(i);
-
-    if (data.length == 1 && i == 0 && i + 1 < mask.length && /^((?!(#|A|N|X)).)*/.test(m)) {
-        text += m;
-        m = mask.charAt(i + 1);
-    }
 
     switch (m) {
       case '#' : if (/\d/.test(c))        {text += c;} else {x = 0;} break;

--- a/src/format.js
+++ b/src/format.js
@@ -26,7 +26,16 @@ export default function (data, mask){
       case 'A' : if (/[a-z]/i.test(c))    {text += c;} else {x = 0;} break;
       case 'N' : if (/[a-z0-9]/i.test(c)) {text += c;} else {x = 0;} break;
       case 'X' : text += c; break;
-      default  : text += m; break;
+      default  : 
+        text += m; 
+        
+        // preserve inputed values added in places where you normally would find
+        // a masked character, ie: the user manually deletes part of the masked string (issue #5)
+        if (c && c !== m) {
+          data += c;
+        }
+
+        break;
     }
   }
   return text;

--- a/src/format.js
+++ b/src/format.js
@@ -29,10 +29,10 @@ export default function (data, mask){
       default  : 
         text += m; 
         
-        // preserve inputed values added in places where you normally would find
-        // a masked character, ie: the user manually deletes part of the masked string (issue #5)
+        // preserve characters that are in the same spot we need to insert a mask
+        // character by shifting the data over to the right (issue #5, & #7)
         if (c && c !== m) {
-          data += c;
+          data = ' ' + data;
         }
 
         break;


### PR DESCRIPTION
Allow the mask to contain multiple non special characters at the beginning. The previous implementation only worked when only the first character was non special.

the following now works for example:
`+1(###)-###-####`