### PR TITLE
Adds optional character to mask

### DIFF
--- a/__tests__/format.test.js
+++ b/__tests__/format.test.js
@@ -121,6 +121,29 @@ describe('One-symbol mask for any input -> X', () => {
   })
 });
 
+describe('Optional character mask', () => {
+
+  test('Should return `(12) 1234-1234` for mask `(##) ####-####?#` and input `1212341234`', () => {
+    let input = '1212341234'
+    let expected = '(12) 1234-1234'
+    let mask = '(##) ####-####?#'
+
+    let actual = format(input, mask)
+
+    expect(actual).toBe(expected)
+  })
+
+  test('Should return `(12) 1234-12345` for mask `(##) ####-####?#` and input `12123412345`', () => {
+    let input = '12123412345'
+    let expected = '(12) 1234-12345'
+    let mask = '(##) ####-####?#'
+
+    let actual = format(input, mask)
+    
+    expect(actual).toBe(expected)
+  })
+})
+
 describe('Real-word masks', () => {
   test('[Time] Should return `11:15:15` for mask `##:##:##` and input `111515`', () => {
     let input = '111515';

--- a/src/format.js
+++ b/src/format.js
@@ -17,14 +17,33 @@ export default function (data, mask){
   }
 
   let text = '';
+
+  // Adds a char offset to allow testing on optional values
+  var cOffset = 0;
+
+  // Cleans data to  avoid value loss on dynamic mask changing
+  for (var i = 0; i < mask.length; i++) {
+    var m = mask.charAt(i)
+    switch(m) {
+      case '#' : break;
+      case 'A' : break;
+      case '?' : break;
+      case 'N' : break;
+      case 'X' : break;
+      default : data = data.replace(m, '')
+    }
+  }
   for (let i = 0, x = 1; x && i < mask.length; ++i) {
-    let c = data.charAt(i);
+    // Uses the optional mask character offset
+    let c = data.charAt(i - cOffset);
     let m = mask.charAt(i);
 
     switch (m) {
       case '#' : if (/\d/.test(c))        {text += c;} else {x = 0;} break;
       case 'A' : if (/[a-z]/i.test(c))    {text += c;} else {x = 0;} break;
       case 'N' : if (/[a-z0-9]/i.test(c)) {text += c;} else {x = 0;} break;
+      // Skips testing if optional field is specified
+      case '?' : cOffset++; break;
       case 'X' : text += c; break;
       default  : 
         text += m; 


### PR DESCRIPTION
Using ```"(##) ####-####?#"``` as mask allows to have the last character as
optional character.

Also avoids value loss on filled inputs mask changing. Try the demo with
111.222.333/444 then change ther mask, the value will change to
111.222.333