### PR TITLE
Allow first mask character to not be special

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,20 +7,25 @@
  * @returns {string} Formatted text
  */
 function format (data, mask){
-  var text = '';
-  var c, m, i, x;
+    if (!mask) return data;
 
-  for (i = 0, x = 1; x && i < mask.length; ++i) {
-    c = data.charAt(i);
-    m = mask.charAt(i);
+    var text = '';
+    for (var i = 0, x = 1; x && i < mask.length; ++i) {
+        var c = data.charAt(i);
+        var m = mask.charAt(i);
 
-    switch (m) {
-      case '#' : if (/\d/.test(c))        {text += c;} else {x = 0;} break;
-      case 'A' : if (/[a-z]/i.test(c))    {text += c;} else {x = 0;} break;
-      case 'N' : if (/[a-z0-9]/i.test(c)) {text += c;} else {x = 0;} break;
-      case 'X' : text += c; break;
-      default  : text += m; break;
-    }
+        if (data.length == 1 && i == 0 && i + 1 < mask.length && /^((?!(#|A|N|X)).)*/.test(m)) {
+            text += m;
+            m = mask.charAt(i + 1);
+        }
+
+        switch (m) {
+            case '#' : if (/\d/.test(c))        {text += c;} else {x = 0;} break;
+            case 'A' : if (/[a-z]/i.test(c))    {text += c;} else {x = 0;} break;
+            case 'N' : if (/[a-z0-9]/i.test(c)) {text += c;} else {x = 0;} break;
+            case 'X' : text += c; break;
+            default  : text += m; break;
+        }
   }
   return text;
 }


### PR DESCRIPTION
It fixes the first mask character bug for `Vue 1.x`. It was already fixed for `v2` in https://github.com/probil/v-mask/commit/ae23140e5cd91af11e10a3d0200ecc442764effb