### PR TITLE
Get native input for custom components

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -33,6 +33,17 @@ function updateMask(el, mask) {
   el.dataset.mask = mask;
 }
 
+/**
+ * Ensure that el is a HTMLInputElement or try finding it.
+ * @param {HTMLInputElement | *} el
+ * @returns {HTMLInputElement | *}
+ */
+function getNativeInput(el){
+  if(el instanceof HTMLInputElement)
+    return el;
+  
+  return el.querySelector('input');
+}
 
 /**
  * Vue directive definition
@@ -47,6 +58,7 @@ export default {
    * @param {?String}                        value
    */
   bind(el, { value }) {
+    el = getNativeInput(el);
     el = queryInputElementInside(el);
 
     updateMask(el, value);
@@ -65,6 +77,7 @@ export default {
    * @param {?String}                        oldValue
    */
   componentUpdated(el, { value, oldValue }) {
+    el = getNativeInput(el);
     el = queryInputElementInside(el);
 
     const isMaskChanged = value !== oldValue;


### PR DESCRIPTION
If the custom component hides the native input underneath its template, we still get the native input. Only expected to work if there is one input underneath the custom component;