### PR TITLE
Bugfix/allow mask false

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -31,7 +31,7 @@ function updateValue(el, force = false) {
   const isUpdateNeeded = value && isValueChanged && isLengthIncreased;
 
   if (force || isUpdateNeeded) {
-    const { conformedValue } = conformToMask(value, mask, { guide: false });
+    const { conformedValue } = mask ? conformToMask(value, mask, { guide: false }) : value;
     el.value = conformedValue;
     triggerInputUpdate(el);
   }

--- a/src/directive.js
+++ b/src/directive.js
@@ -45,7 +45,7 @@ function updateValue(el, force = false) {
  * @param {String}           mask
  */
 function updateMask(el, mask) {
-  options.partiallyUpdate(el, { mask: stringMaskToRegExpMask(mask) });
+  options.partiallyUpdate(el, { mask: mask ? stringMaskToRegExpMask(mask) : false });
 }
 
 

--- a/tests/e2e/spec/basic.js
+++ b/tests/e2e/spec/basic.js
@@ -30,3 +30,19 @@ test('Does nothing if backspace is pressed multiple times on empty field', async
     .pressKey('backspace')
     .expect(el.value).eql(''); // eslint-disable-line newline-per-chained-call
 });
+
+test('Does not affect the input', async (t) => {
+  const el = Selector('input#no-mask');
+  await t
+    .typeText(el, '2315')
+    .expect(el.value).eql('2315')
+    .typeText(el, 'ABCD')
+    .expect(el.value).eql('2315ABCD')
+	.pressKey('backspace')
+    .pressKey('backspace')
+    .pressKey('backspace')
+	.pressKey('backspace')
+	.expect(el.value).eql('2315')
+	.typeText(el, 'efgh')
+	.expect(el.value).eql('2315efgh')
+});


### PR DESCRIPTION
When using inputs in a v-for loop we sometimes don't need a mask, but can't conditionally apply the attribute. Setting false at the moment is a TypeError.