### PR TITLE
Fix optional next character to respect type

### DIFF
--- a/src/utils/regexp.js
+++ b/src/utils/regexp.js
@@ -23,8 +23,8 @@ export const makeRegexpOptional = (charRegexp) => (
   stringToRegexp(
     charRegexp.toString()
       .replace(
-        /.(\/)[gmiyus]{0,6}$/,
-        (match) => match.replace('/', '?/'),
+        /[^\/].*(\/)[gmiyus]{0,6}$/,
+        (match) => match.replace(/^([^\^])/, '^$1').replace(/[^\$]$/, '$/').replace('\$/', '?$/'),
       ),
   )
 );


### PR DESCRIPTION
I found optional characters did not have their types respected. For example:

(###) ###-#### ?#?#?#

Would allow (555) 555-5555 ddd

I added anchors (if anchors are not already present) to makeRegexpOptional() so the only the optional character would match.