### PR TITLE
Checks for value change before updating input

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-param-reassign */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import conformToMask from 'text-mask-core/src/conformToMask';
-import stringMaskToRegExpMask from './stringMaskToRegExpMask';
-import { trigger, queryInputElementInside } from './utils';
-import { isAndroid, isChrome } from './utils/env';
-import createOptions from './createOptions';
+import conformToMask from "text-mask-core/src/conformToMask";
+import stringMaskToRegExpMask from "./stringMaskToRegExpMask";
+import { trigger, queryInputElementInside } from "./utils";
+import { isAndroid, isChrome } from "./utils/env";
+import createOptions from "./createOptions";
 
 const options = createOptions();
 
 function triggerInputUpdate(el) {
-  const fn = trigger.bind(null, el, 'input');
+  const fn = trigger.bind(null, el, "input");
   if (isAndroid && isChrome) {
     setTimeout(fn, 0);
   } else {
@@ -32,8 +32,11 @@ function updateValue(el, force = false) {
 
   if (force || isUpdateNeeded) {
     const { conformedValue } = conformToMask(value, mask, { guide: false });
-    el.value = conformedValue;
-    triggerInputUpdate(el);
+
+    if (conformedValue !== value) {
+      el.value = conformedValue;
+      triggerInputUpdate(el);
+    }
   }
 
   options.partiallyUpdate(el, { previousValue: value });
@@ -48,12 +51,10 @@ function updateMask(el, mask) {
   options.partiallyUpdate(el, { mask: stringMaskToRegExpMask(mask) });
 }
 
-
 /**
  * Vue directive definition
  */
 export default {
-
   /**
    * Called only once, when the directive is first bound to the element.
    * This is where you can do one-time setup work.

--- a/src/directive.js
+++ b/src/directive.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-param-reassign */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import conformToMask from "text-mask-core/src/conformToMask";
-import stringMaskToRegExpMask from "./stringMaskToRegExpMask";
-import { trigger, queryInputElementInside } from "./utils";
-import { isAndroid, isChrome } from "./utils/env";
-import createOptions from "./createOptions";
+import conformToMask from 'text-mask-core/src/conformToMask';
+import stringMaskToRegExpMask from './stringMaskToRegExpMask';
+import { trigger, queryInputElementInside } from './utils';
+import { isAndroid, isChrome } from './utils/env';
+import createOptions from './createOptions';
 
 const options = createOptions();
 
 function triggerInputUpdate(el) {
-  const fn = trigger.bind(null, el, "input");
+  const fn = trigger.bind(null, el, 'input');
   if (isAndroid && isChrome) {
     setTimeout(fn, 0);
   } else {
@@ -51,10 +51,12 @@ function updateMask(el, mask) {
   options.partiallyUpdate(el, { mask: stringMaskToRegExpMask(mask) });
 }
 
+
 /**
  * Vue directive definition
  */
 export default {
+
   /**
    * Called only once, when the directive is first bound to the element.
    * This is where you can do one-time setup work.


### PR DESCRIPTION
This is a fix for https://github.com/probil/v-mask/issues/460

`@input` will still call twice when masking changes the value, however, it removes unnecessary updating of unchanged value.