### PR TITLE
fix: #454 android doesnt apply mask

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -3,19 +3,19 @@
 import conformToMask from 'text-mask-core/src/conformToMask';
 import { stringMaskToRegExpMask, arrayMaskToRegExpMask } from './maskToRegExpMask';
 import { trigger, queryInputElementInside } from './utils';
-import { isAndroid, isChrome } from './utils/env';
 import createOptions from './createOptions';
 import { defaultMaskReplacers } from './constants';
 
 const options = createOptions();
 
+/**
+ * Convenience wrapper for `trigger(el, 'input')`, which raises
+ * an event for Vue to detect a value change.
+ *
+ * @param {HTMLInputElement} el
+ */
 function triggerInputUpdate(el) {
-  const fn = trigger.bind(null, el, 'input');
-  if (isAndroid && isChrome) {
-    setTimeout(fn, 0);
-  } else {
-    fn();
-  }
+  trigger(el, 'input');
 }
 
 /**
@@ -62,7 +62,7 @@ function updateMask(el, inputMask, maskReplacers) {
 /**
  * Merge custom mask replacers with default mask replacers
  * @param {Object<string, RegExp>} maskReplacers
- * @param {Objext<string, RegExp>} baseMaskReplacers
+ * @param {Object<string, RegExp>} baseMaskReplacers
  * @return {Object} The extended mask replacers
  */
 function extendMaskReplacers(maskReplacers, baseMaskReplacers = defaultMaskReplacers) {


### PR DESCRIPTION
I've gone ahead and implemented the changes that were tested by some other users (@propelinc and @luizmacfilho) in the correct places to address issue #454 . I did change one thing - instead of binding `null` to the `trigger` function, I removed that entirely since there were no references to `this` in that specific function.

I ran the jest tests, build & e2e tests and they passed.
![image](https://user-images.githubusercontent.com/820669/83313632-b7fe6100-a1dc-11ea-91b7-88288779e0c7.png)

![image](https://user-images.githubusercontent.com/820669/83313621-ac129f00-a1dc-11ea-8c34-b0b096784b77.png)


Sadly, I don't have a good way of testing the changes in Android since I live in an Apple household and don't have access to any of those devices. Would anyone here be able to look at that for me?

Another thing I noticed was that the `setTimeout` that was proposed to be removed was added in this commit (https://github.com/probil/v-mask/commit/4e253faba6f17f333e10a496c4a12e99f50fedd8) by @probil so I wanted to get a bit more context around that, since removing it wholesale seemed a bit too obvious.

If anyone has any recommendations or changes, let me know. I'd be happy to make them. Good Android support for this (great) library is wanted!

cc: @NoahLE-RG